### PR TITLE
test(cli): add smoke tests to verify core commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+import pytest
+from click.testing import CliRunner
+
+from syshardn.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--version"],
+        ["--help"],
+    ],
+)
+def test_cli_options(runner, args):
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == 0
+    assert result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        # Use --help to verify command exists and parses options without running actual logic
+        ["check", "--help"],
+        ["apply", "--help"],
+        ["report", "--help"],
+        ["rollback", "--help"],
+        ["list-rules", "--help"],
+    ],
+)
+def test_cli_subcommands(runner, args):
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == 0
+    assert result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,11 +9,6 @@ def runner():
     return CliRunner()
 
 
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
 @pytest.mark.parametrize(
     "args",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,32 +10,34 @@ def runner():
 
 
 @pytest.mark.parametrize(
-    "args",
+    "args, substrings",
     [
-        ["--version"],
-        ["--help"],
+        (["--version"], ["SysHardn", "version"]),
+        (["--help"], ["Usage:", "Options:", "Commands:"]),
     ],
+    # Optionally specify IDs for nicer pytest results
+    ids=["version", "help"],
 )
-def test_cli_options(runner, args):
+def test_cli_options(runner, args, substrings):
     result = runner.invoke(cli, args)
 
     assert result.exit_code == 0
-    assert result.output
+    for substring in substrings:
+        assert substring in result.output
 
 
 @pytest.mark.parametrize(
-    "args",
+    "command",
     [
-        # Use --help to verify command exists and parses options without running actual logic
-        ["check", "--help"],
-        ["apply", "--help"],
-        ["report", "--help"],
-        ["rollback", "--help"],
-        ["list-rules", "--help"],
+        "check",
+        "apply",
+        "report",
+        "rollback",
+        "list-rules",
     ],
 )
-def test_cli_subcommands(runner, args):
-    result = runner.invoke(cli, args)
+def test_cli_commands(runner, command):
+    result = runner.invoke(cli, [command, "--help"])
 
     assert result.exit_code == 0
-    assert result.output
+    assert "Usage:" in result.output


### PR DESCRIPTION
Adds minimal CLI smoke tests to verify the main entry point and subcommands are registered and parsed correctly.

Running the tests: 

```sh
pytest tests/test_cli.py -v
tests/test_cli.py::test_cli_options[version] PASSED
tests/test_cli.py::test_cli_options[help] PASSED 
tests/test_cli.py::test_cli_commands[check] PASSED
tests/test_cli.py::test_cli_commands[apply] PASSED 
tests/test_cli.py::test_cli_commands[report] PASSED 
tests/test_cli.py::test_cli_commands[rollback] PASSED
tests/test_cli.py::test_cli_commands[list-rules] PASSED
```

Closes #3